### PR TITLE
Update skipped tasks view

### DIFF
--- a/src/stores.ts
+++ b/src/stores.ts
@@ -92,7 +92,10 @@ export const nodeStore: Readable<NodeType[]> = derived(taskStore, $taskStore => 
           id: String(index + idOffset),
           position: { x: 500 + (index + 1) * 250, y: 150 },
           data: {
-            html: `<img src="data:image/png;base64,${task.receipt?.out[1]}" draggable="false" />`
+            html:
+              task.status === 'skipped' ?
+                `<img src="data:image/png;base64,${task.receipt?.out[ 1 ]}" draggable="false" style="filter: opacity(75%)" />` :
+                `<img src="data:image/png;base64,${task.receipt?.out[ 1 ]}" draggable="false" />`
           },
           width: 150,
           height: 150,
@@ -108,6 +111,23 @@ export const nodeStore: Readable<NodeType[]> = derived(taskStore, $taskStore => 
     if (task.status === 'success' || task.status === 'skipped') {
       const idOffset = 5
 
+      // Check for a matching task in workflow one
+      const matchingOneTask = $taskStore.one.find(t => t.operation === task.operation)
+
+      if (
+        matchingOneTask &&
+        (matchingOneTask.status === 'success' || matchingOneTask.status === 'skipped')
+      ) {
+        const nodeIndex = matchingOneTask.id - 1
+        const updatedHtml = `${workflowOneNodes[nodeIndex].data.html.slice(0, -2)} style="filter: opacity(75%)" />`
+
+        // Update node in workflow one with opacity to indicate the skipped task
+        workflowOneNodes[nodeIndex] = { ...workflowOneNodes[nodeIndex], data: { html: updatedHtml }}
+
+        // Skip adding new nodes to workflow two
+        return nodes
+      }
+
       // @ts-ignore
       nodes = [
         ...nodes,
@@ -115,7 +135,10 @@ export const nodeStore: Readable<NodeType[]> = derived(taskStore, $taskStore => 
           id: String(index + idOffset),
           position: { x: 500 + (index + 1) * 250, y: 450 },
           data: {
-            html: `<img src="data:image/png;base64,${task.receipt?.out[1]}" draggable="false" />`
+            html:
+              task.status === 'skipped' ?
+                `<img src="data:image/png;base64,${task.receipt?.out[ 1 ]}" draggable="false" style="filter: opacity(75%)" />` :
+                `<img src="data:image/png;base64,${task.receipt?.out[ 1 ]}" draggable="false" />`
           },
           width: 150,
           height: 150,
@@ -164,16 +187,21 @@ export const edgeStore = derived(nodeStore, $nodeStore => {
 
   // Workflow Two
 
-  if (nodeIds.includes('1') && nodeIds.includes('5')) {
-    edges = [...edges, { id: 'e1-5', source: '1', target: '5', label: 'Crop', arrow: true }]
-  }
+  if (nodeIds.includes('1') && nodeIds.includes('2') && nodeIds.includes('3') && nodeIds.includes('7')) {
+    edges = [ ...edges, { id: 'e3-7', source: '3', target: '7', label: 'Grayscale', arrow: true } ]
 
-  if (nodeIds.includes('5') && nodeIds.includes('6')) {
-    edges = [...edges, { id: 'e5-6', source: '5', target: '6', label: 'Rotate90', arrow: true }]
-  }
+  } else {
+    if (nodeIds.includes('1') && nodeIds.includes('5')) {
+      edges = [ ...edges, { id: 'e1-5', source: '1', target: '5', label: 'Crop', arrow: true } ]
+    }
 
-  if (nodeIds.includes('6') && nodeIds.includes('7')) {
-    edges = [...edges, { id: 'e6-7', source: '6', target: '7', label: 'Grayscale', arrow: true }]
+    if (nodeIds.includes('5') && nodeIds.includes('6')) {
+      edges = [ ...edges, { id: 'e5-6', source: '5', target: '6', label: 'Rotate90', arrow: true } ]
+    }
+
+    if (nodeIds.includes('6') && nodeIds.includes('7')) {
+      edges = [ ...edges, { id: 'e6-7', source: '6', target: '7', label: 'Grayscale', arrow: true } ]
+    }
   }
 
   return edges


### PR DESCRIPTION
This PR implements the following features:

- [x] Connect workflow two final node to workflow one when tasks have already been completed are skipped
- [x] Add opacity to nodes when the task was skipped

When workflow two skips tasks from workflow one, the skipped tasks in workflow one are updated with opacity if they did not have it before.

Note that this is all quite brittle. For example, running workflow one after workflow two will not connect to existing workflow two nodes. We can refactor at some point to make the view layer more flexible.